### PR TITLE
feat: add space to engine interface

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,6 +13,12 @@ webhooks:
       path: /mutate--v1-pod
   failurePolicy: Fail
   name: mpod-v1.kb.io
+  objectSelector:
+    matchExpressions:
+      - key: agent.octopus.com/permissions
+        operator: In
+        values:
+        - enabled
   rules:
   - apiGroups:
     - ""

--- a/internal/rules/engine.go
+++ b/internal/rules/engine.go
@@ -15,6 +15,7 @@ type Scope struct {
 	Environment string `json:"environment"`
 	Tenant      string `json:"tenant"`
 	Step        string `json:"step"`
+	Space       string `json:"space"`
 }
 
 type Rule struct {
@@ -30,6 +31,10 @@ type Engine interface {
 type InMemoryEngine struct {
 	rules map[AgentName]map[Scope]ServiceAccountName
 	// client kubernetes.Interface
+}
+
+func (s *Scope) IsEmpty() bool {
+	return s.Project == "" && s.Environment == "" && s.Tenant == "" && s.Step == "" && s.Space == ""
 }
 
 func NewInMemoryEngine() InMemoryEngine {

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -87,8 +87,12 @@ func (d *PodCustomDefaulter) Default(ctx context.Context, obj runtime.Object) er
 }
 
 func (d *PodCustomDefaulter) shouldRunOnPod(_ context.Context, p *corev1.Pod) bool {
-	if _, ok := p.Labels[EnabledLabelKey]; ok {
-		return true
+	// This condition should always be true, as our webhook configuration only selects pods with the label.
+	// this is here for safety and to allow an easy entry point for further logic if necessary
+	if val, ok := p.Labels[EnabledLabelKey]; ok {
+		if val == "enabled" {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -43,13 +43,14 @@ var _ = Describe("Pod Webhook", func() {
 				Name:      "test-pod",
 				Namespace: "default",
 				Labels: map[string]string{
-					EnabledLabelKey: "true",
+					EnabledLabelKey: "enabled",
 				},
 				Annotations: map[string]string{
 					ProjectAnnotationKey:     "my-project",
 					EnvironmentAnnotationKey: "my-environment",
 					TenantAnnotationKey:      "my-tenant",
 					StepAnnotationKey:        "my-step",
+					SpaceAnnotationKey:       "my-space",
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -68,6 +69,7 @@ var _ = Describe("Pod Webhook", func() {
 			Environment: "my-environment",
 			Tenant:      "my-tenant",
 			Step:        "my-step",
+			Space:       "my-space",
 		}
 	})
 


### PR DESCRIPTION
This PR adds spaces to the scope in the engine. It also adds minor changes to the selectors used to target pods with the webhook.
