### PR TITLE
fix: update chart name

### DIFF
--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: octopus-permissions-controller
+name: octopus-permissions-controller-chart
 description: A Helm chart to distribute octopus-permissions-controller
 type: application
 


### PR DESCRIPTION
We recently regenerated all helm charts, but this has caused the release process to break due to a naming mismatch.

This PR fixes this naming mismatch, but we will need to re-tag a new version of the helm chart, so it's worth merging this as a `fix` rather than a `chore`
