### PR TITLE
docs: fix verb agreement in samples NOTE

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can apply the samples (examples) from the config/sample:
 kubectl apply -k config/samples/
 ```
 
->**NOTE**: Ensure that the samples has default values to test it out.
+>**NOTE**: Ensure that the samples have default values to test it out.
 
 ### To Uninstall
 **Delete the instances (CRs) from the cluster:**


### PR DESCRIPTION
Tiny grammar fix: 'the samples has default values' → 'have' (plural subject).